### PR TITLE
Add a hook for NtQueryDirectoryObject

### DIFF
--- a/cuckoomon.c
+++ b/cuckoomon.c
@@ -108,6 +108,7 @@ static hook_t g_hooks[] = {
     HOOK(ntdll, NtSetInformationFile),
     HOOK(ntdll, NtOpenDirectoryObject),
     HOOK(ntdll, NtCreateDirectoryObject),
+    HOOK(ntdll, NtQueryDirectoryObject),
 
     // CreateDirectoryExA calls CreateDirectoryExW
     // CreateDirectoryW does not call CreateDirectoryExW

--- a/hook_file.c
+++ b/hook_file.c
@@ -605,6 +605,24 @@ HOOKDEF(NTSTATUS, WINAPI, NtCreateDirectoryObject,
     return ret;
 }
 
+HOOKDEF(NTSTATUS, WINAPI, NtQueryDirectoryObject,
+  __in       HANDLE DirectoryHandle,
+  __out_opt  PVOID Buffer,
+  __in       ULONG Length,
+  __in       BOOLEAN ReturnSingleEntry,
+  __in       BOOLEAN RestartScan,
+  __inout    PULONG Context,
+  __out_opt  PULONG ReturnLength
+) {
+    NTSTATUS ret = Old_NtQueryDirectoryObject(DirectoryHandle, Buffer, Length,
+        ReturnSingleEntry, RestartScan, Context, ReturnLength);
+    // Don't log STATUS_BUFFER_TOO_SMALL
+    if (ret != 0xC0000023)
+        LOQ_ntstatus("filesystem", "p", "DirectoryHandle", DirectoryHandle);
+
+    return ret;
+}
+
 HOOKDEF(BOOL, WINAPI, CreateDirectoryW,
     __in      LPWSTR lpPathName,
     __in_opt  LPSECURITY_ATTRIBUTES lpSecurityAttributes

--- a/hooks.h
+++ b/hooks.h
@@ -142,6 +142,16 @@ extern HOOKDEF(NTSTATUS, WINAPI, NtCreateDirectoryObject,
     __in   POBJECT_ATTRIBUTES ObjectAttributes
 );
 
+extern HOOKDEF(NTSTATUS, WINAPI, NtQueryDirectoryObject,
+  __in       HANDLE DirectoryHandle,
+  __out_opt  PVOID Buffer,
+  __in       ULONG Length,
+  __in       BOOLEAN ReturnSingleEntry,
+  __in       BOOLEAN RestartScan,
+  __inout    PULONG Context,
+  __out_opt  PULONG ReturnLength
+);
+
 extern HOOKDEF(BOOL, WINAPI, MoveFileWithProgressW,
     __in      LPWSTR lpExistingFileName,
     __in_opt  LPWSTR lpNewFileName,


### PR DESCRIPTION
We'll use this for some additional AntiVM detections. May add in proper
buffer parsing later, but for now we can detect enumerations from calls
to this API alone.
